### PR TITLE
Drop usage of obsolete Manifest & fix compilation

### DIFF
--- a/src/main/scala/scallion/Parsing.scala
+++ b/src/main/scala/scallion/Parsing.scala
@@ -1024,9 +1024,9 @@ trait Parsing { self: Syntaxes =>
 
       def epsilon[A](value: A): Tree[A] = {
         new Success(value) {
-          override val nullable: Option[A] = Some(value)
+          override val nullable: Option[A] = Some(this.value)
           override val first: HashSet[Kind] = HashSet()
-          override val syntax: Syntax[A] = self.epsilon(value)
+          override val syntax: Syntax[A] = self.epsilon(this.value)
         }
       }
     }

--- a/src/main/scala/scallion/Syntaxes.scala
+++ b/src/main/scala/scallion/Syntaxes.scala
@@ -19,6 +19,7 @@ import scala.annotation.implicitNotFound
 import scala.language.higherKinds
 import scala.util.Try
 import scala.collection.mutable.Map
+import scala.reflect.TypeTest
 
 /** Contains the definition of syntaxes. */
 trait Syntaxes {
@@ -300,7 +301,7 @@ trait Syntaxes {
       *
       * @group combinator
       */
-    def up[B >: A](implicit ev: Manifest[A]): Syntax[B] =
+    def up[B >: A](implicit ev: TypeTest[B, A]): Syntax[B] =
       this.map((x: A) => x, (y: B) => ev.unapply(y) match {
         case None => Seq()
         case Some(x) => Seq(x)


### PR DESCRIPTION
Turns out the existential error problem goes away if we use the newer (and sound!) abstraction, probably because it is covariant.